### PR TITLE
Hotfix - fix handling of error cards, change text separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ There is an example file for Russian in [settings/language_configs](./settings/l
 Call Ankifier from the command line with the following arguments:
 - `--config-file`: the configuration file for Ankifier. 
 - `--input-file`: the vocabulary list to process. Each entry should be on a new line and the entire file should be in one language. 
-- `--output-file`: the file to output Anki cards in plain text format. Each card will be on a new line in the format `front;back;part-of-speech`.  
+- `--output-file`: the file to output Anki cards in plain text format. Each card will be on a new line in the format `front|back|part-of-speech`.  
 - `--additional-outputs-file`: the file to output additional outputs (examples, related words, synonyms, antonyms). These *are not* Anki cards: it's up to you to browse through this file and decide what to discard and what to pass to Ankifier for a second pass. 
 - `--language`: the language for the input file, matching one of the language settings in the config file. 

--- a/ankifier/card.py
+++ b/ankifier/card.py
@@ -5,7 +5,7 @@ class Card:
         self.pos = pos
 
     def __str__(self):
-        return f"{self.front}; {self.back}; {self.pos}"
+        return f"{self.front}|{self.back}|{self.pos}"
     
     def __repr__(self):
         return self.__str__

--- a/ankifier/phrase.py
+++ b/ankifier/phrase.py
@@ -55,9 +55,11 @@ class Word:
             config_back = config["back"]
             
             # Generate card just for this word
-            front = ", ".join(self.retrieve_fields(entry, config_front))
-            back = "<br>".join(self.retrieve_fields(entry, config_back))
-            if front is not None and back is not None:
+            front_contents = self.retrieve_fields(entry, config_front)
+            back_contents = self.retrieve_fields(entry, config_back)
+            if front_contents is not None and back_contents is not None:
+                front = ", ".join(front_contents)
+                back = "<br>".join(back_contents)
                 card = Card(front, back, pos)
                 cards_to_output.append(card)
 
@@ -108,6 +110,8 @@ class Phrase:
         # Look up all the individual (lemmatized) words and generate cards for these
         tokens = self.pre_process_phrase(self.phrase)
         for (lemma, pos, detailed_pos) in tokens:
+            if pos == "PROPN":
+                lemma = lemma.capitalize()
             word = Word(lemma, pos, self.config, self.coll)
             cards_for_lemma = word.generate_cards()
             cards.extend(cards_for_lemma)


### PR DESCRIPTION
Changes made after doing a run of the tool on an example file:
- Use | instead of ; to separate entries, because some definitions and examples have ; in them (which breaks Anki's parsing)
- Fix handling of cards where the front or back can't be generated
- Capitalize proper nouns before generating cards from them, or else they can't be looked up in Wikipedia